### PR TITLE
feat: added handling for using buildDir instead of assuming dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
+build
 *.tgz

--- a/src/swcPlugin.ts
+++ b/src/swcPlugin.ts
@@ -2,19 +2,24 @@ import { ResolvedCloudflareSpaConfig } from './CloudflareSpaConfig';
 import { getViteConfig } from './utils';
 import { transform as swcTransform } from '@swc/core';
 import { writeFile } from 'node:fs';
-import type { PluginOption } from 'vite';
+import path from 'node:path';
+import type { PluginOption, ResolvedConfig } from 'vite';
 
 export const swcPlugin = (config: ResolvedCloudflareSpaConfig) => {
   const { allowedApiPaths, excludedApiPaths, swcConfig } = config;
-
+  let _resolvedConfig: ResolvedConfig;
   return {
     name: 'vite-plugin-wrangler-spa:swc',
     apply: (_, { command, mode }) => command === 'build' && mode === 'page-function',
     config: () => getViteConfig(config),
+    configResolved(resolvedConfig) {
+      _resolvedConfig = resolvedConfig;
+    },
     transform: (code) => swcTransform(code, swcConfig),
-    writeBundle: async () =>
-      await writeFile(
-        'dist/_routes.json',
+    writeBundle: async () => {
+      const outDir = _resolvedConfig.build?.outDir ?? 'dist';
+      return await writeFile(
+        path.join(outDir, '_routes.json'),
         JSON.stringify(
           {
             version: 1,
@@ -25,6 +30,7 @@ export const swcPlugin = (config: ResolvedCloudflareSpaConfig) => {
           2
         ),
         (err) => (err ? console.error(err.message) : null)
-      ),
+      );
+    },
   } as PluginOption;
 };


### PR DESCRIPTION
Hi,

We use a different build dir in our vite config. I patched it locally with patch-package, but thought this might be useful for others.

I'm in no way an expert in vite plugins so please do tell me if this is wrong

